### PR TITLE
Expand range of @types/three

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@types/three": "^0.163.0"
+    "@types/three": "*"
   },
   "devDependencies": {
     "fs-extra": "^11.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 dependencies:
   '@types/three':
-    specifier: ^0.163.0
+    specifier: '*'
     version: 0.163.0
 
 devDependencies:


### PR DESCRIPTION
Currently the `@types/three` is locked into `@types/three@0.163.0`, but it would be nice to allow different major versions of `@types/three` so that a user can match the version of `@types/three` with the version their app is using. For example, I just upgraded my app to `@types/three@0.164.0`, but `@types/three@0.163.0` is still installed because of this dependency. With this change, I would be able to make them all resolve to `@types/three@0.164.0`. This would allow more flexibility for users to use whatever version of `@types/three` they're using in their app.