### PR TITLE
Make `three` dependency explicitly optional for “vanilla webgl” users

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import type * as THREE from 'three';
 import { Panel } from './panel';
 
 interface StatsOptions {

--- a/package.json
+++ b/package.json
@@ -27,20 +27,21 @@
     "build": "tsc && vite build && rollup -c && node ./scripts/copyBuild.js",
     "preview": "vite preview"
   },
-  "dependencies": {
-    "@types/three": "*",
-    "three": "^0.170.0"
-  },
   "devDependencies": {
     "fs-extra": "^11.2.0",
     "path": "^0.12.7",
     "rollup": "^4.24.3",
     "rollup-plugin-dts": "^5.3.1",
     "typescript": "^5.6.3",
-    "vite": "^4.5.5"
+    "vite": "^4.5.5",
+    "@types/three": "*"
   },
   "peerDependencies": {
-    "three": "*",
-    "@types/three": "*"
+    "three": "*"
+  },
+  "peerDependenciesMeta": {
+    "three": {
+      "optional": true
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,13 +8,13 @@ importers:
 
   .:
     dependencies:
+      three:
+        specifier: '*'
+        version: 0.170.0
+    devDependencies:
       '@types/three':
         specifier: '*'
         version: 0.169.0
-      three:
-        specifier: ^0.170.0
-        version: 0.170.0
-    devDependencies:
       fs-extra:
         specifier: ^11.2.0
         version: 11.2.0


### PR DESCRIPTION
Avoid requiring that “vanilla webgl” users install the `three` package, by removing the direct dependency and marking the peer dependency as optional.

Before v3, stats-gl did not have `three` as a dependency, just the type definitions (`@types/three`). However, stats-gl v3 added `three` to the dependencies, but as I can tell only the types are actually used in the project.

This change allows users who are using stats-gl to time “vanilla” webgl programs to do so without installing or bundling the `three` package.

I’m proposing the following changes to improve DX for non-threejs users of this package:
- Replace the `three` import in main.js with an `import type`, to make it explicit that `three` doesn’t need to be bundled on behalf of `stats-gl`
- Put `@types/three` in `devDependencies` instead of `dependencies`, since type definitions are only used at build time, not at runtime
- Remove `three` from dependencies, since it’s not used directly by this library
- Add a `peerDependenciesMeta` to indicate that the *peer* dependency on `three` is optional and does not *need* to be installed when installing this package.


This is my first contribution to this package, so please let me know if there’s anything I missed or overlooked.