### PR TITLE
Update link to StatsGl component documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ const Scene = () => (
 
 ### Tresjs (Vue)
 
-A `<StatsGl />` component is available through [cientos](https://cientos.tresjs.org/guide/misc/stats-gl.html):
+A `<StatsGl />` component is available through [cientos](https://cientos.tresjs.org/api/debug-performance/stats-gl):
 
 ```vue
 <script setup lang="ts">


### PR DESCRIPTION
Fix for a link leading to a 404 error page in the README file