### PR TITLE
feat: Rewrite WebGPU timestamp pipeline. multi-pass, compute, dynamic pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,49 @@ function animate() {
 animate();
 ```
 
+#### Multiple passes per frame (render + compute)
+
+`getTimestampWrites('render')` and `getTimestampWrites('compute')` allocate independent
+timestamp pairs. Each call consumes one pair from the per-frame budget; counters reset
+on the next `stats.begin()`. Render-pass durations sum into the **GPU** panel,
+compute-pass durations into the **CPT** panel.
+
+```js
+const stats = new Stats({ trackGPU: true, trackCPT: true });
+stats.init(device);
+
+function animate() {
+  stats.begin();
+
+  const encoder = device.createCommandEncoder();
+
+  const compute = encoder.beginComputePass({
+    timestampWrites: stats.getTimestampWrites('compute')
+  });
+  // ... dispatchWorkgroups ...
+  compute.end();
+
+  const shadowPass = encoder.beginRenderPass({
+    colorAttachments: [...],
+    timestampWrites: stats.getTimestampWrites('render')
+  });
+  // ... shadow draw calls ...
+  shadowPass.end();
+
+  const mainPass = encoder.beginRenderPass({
+    colorAttachments: [...],
+    timestampWrites: stats.getTimestampWrites('render')
+  });
+  // ... main draw calls ...
+  mainPass.end();
+
+  stats.end(encoder);
+  device.queue.submit([encoder.finish()]);
+  stats.update();
+  requestAnimationFrame(animate);
+}
+```
+
 ### React Three Fiber
 
 A `<StatsGl />` component is available through [@react-three/drei](https://github.com/pmndrs/drei):
@@ -133,12 +176,13 @@ import { StatsGl } from '@tresjs/cientos'
 | `trackFPS` | boolean | `true` | Enable built-in FPS and CPU panels |
 | `trackGPU` | boolean | `false` | Enable GPU timing (requires extension support) |
 | `trackHz` | boolean | `false` | Enable refresh rate detection |
-| `trackCPT` | boolean | `false` | Enable Three.js compute shader timing (WebGPU only) |
+| `trackCPT` | boolean | `false` | Enable compute-pass timing (WebGPU). Adds the **CPT** panel. |
 | `logsPerSecond` | number | `4` | How often to update text display |
 | `graphsPerSecond` | number | `30` | How often to update graphs |
 | `samplesLog` | number | `40` | Number of samples for text averaging |
 | `samplesGraph` | number | `10` | Number of samples for graph averaging |
 | `precision` | number | `2` | Decimal places for CPU/GPU values |
+| `maxTimestampPairs` | number | `2048` | Max begin/end timestamp pairs per frame on the native WebGPU path |
 | `minimal` | boolean | `false` | Minimal mode - click to cycle panels |
 | `horizontal` | boolean | `true` | Horizontal panel layout |
 | `mode` | number | `0` | Initial panel (0=FPS, 1=CPU, 2=GPU) |
@@ -387,13 +431,14 @@ Main class with DOM rendering.
 import Stats from 'stats-gl';
 
 const stats = new Stats(options);
-stats.init(renderer);           // Initialize with Three.js renderer, canvas, or GPUDevice
-stats.begin();                  // Start timing (auto-called for Three.js)
-stats.end(encoder?);            // End timing (pass encoder for native WebGPU)
-stats.update();                 // Update display
-stats.setData(data);            // Set external timing data
-stats.getTimestampWrites();     // Get timestampWrites for native WebGPU render pass
-stats.dispose();                // Clean up resources
+stats.init(renderer);                 // Initialize with Three.js renderer, canvas, or GPUDevice
+stats.begin();                        // Start timing (auto-called for Three.js)
+stats.end(encoder?);                  // End timing (pass encoder for native WebGPU)
+stats.update();                       // Update display
+stats.setData(data);                  // Set external timing data
+stats.getTimestampWrites('render');   // Allocate a render-pass timestamp pair
+stats.getTimestampWrites('compute');  // Allocate a compute-pass timestamp pair
+stats.dispose();                      // Clean up resources
 ```
 
 ### Named Exports

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -8,6 +8,22 @@ export interface StatsCoreOptions {
   samplesLog?: number;
   samplesGraph?: number;
   precision?: number;
+  /**
+   * Maximum number of timestamp pairs (begin/end) the native WebGPU path can record per frame.
+   * Each pair costs 16 bytes in a single QuerySet. Default 2048 (matches Three.js's WebGPUTimestampQueryPool).
+   */
+  maxTimestampPairs?: number;
+}
+
+export type TimestampPassType = 'render' | 'compute';
+
+interface InFlightTimestampFrame {
+  buffer: GPUBuffer;
+  pairCount: number;
+  slotTypes: ReadonlyArray<TimestampPassType>;
+  mapPromise: Promise<void> | null;
+  ready: boolean;
+  error: unknown | null;
 }
 
 export interface QueryInfo {
@@ -58,13 +74,23 @@ export class StatsCore {
   protected threeRendererPatched = false;
 
   // Native WebGPU timing support
+  public maxTimestampPairs: number = 2048;
   protected webgpuNative: boolean = false;
   protected gpuQuerySet: GPUQuerySet | null = null;
   protected gpuResolveBuffer: GPUBuffer | null = null;
-  protected gpuReadBuffers: GPUBuffer[] = [];
-  protected gpuWriteBufferIndex: number = 0; // Buffer to write to this frame
-  protected gpuFrameCount: number = 0; // Track frames for first-frame skip
-  protected pendingResolve: Promise<number> | null = null;
+  protected gpuTimestampBufferSize: number = 0; // querySet.count * 8
+
+  // Per-frame slot allocator (reset on begin())
+  protected frameCursor: number = 0;
+  protected slotTypes: TimestampPassType[] = [];
+
+  // Async readback infrastructure
+  protected readBufferPool: GPUBuffer[] = []; // unmapped buffers ready for reuse
+  protected inFlightFrames: InFlightTimestampFrame[] = [];
+  protected readonly poolWarnThreshold: number = 8;
+  protected warnedMapError: boolean = false;
+  protected warnedSlotOverflow: boolean = false;
+  protected warnedPoolGrowth: boolean = false;
 
   protected beginTime: number;
   protected prevCpuTime: number;
@@ -95,7 +121,8 @@ export class StatsCore {
     graphsPerSecond = 30,
     samplesLog = 40,
     samplesGraph = 10,
-    precision = 2
+    precision = 2,
+    maxTimestampPairs = 2048
   }: StatsCoreOptions = {}) {
     this.trackGPU = trackGPU;
     this.trackCPT = trackCPT;
@@ -106,6 +133,7 @@ export class StatsCore {
     this.precision = precision;
     this.logsPerSecond = logsPerSecond;
     this.graphsPerSecond = graphsPerSecond;
+    this.maxTimestampPairs = Math.max(1, maxTimestampPairs);
 
     const now = performance.now();
     this.prevGraphTime = now;
@@ -157,25 +185,37 @@ export class StatsCore {
   protected initializeWebGPUTiming(): void {
     if (!this.gpuDevice) return;
 
-    // Create query set for 2 timestamps (begin + end)
+    const count = this.maxTimestampPairs * 2;
+    this.gpuTimestampBufferSize = count * 8; // 8 bytes per u64 timestamp
+
     this.gpuQuerySet = this.gpuDevice.createQuerySet({
       type: 'timestamp',
-      count: 2
+      count
     });
 
-    // Buffer to resolve query results (2 * 8 bytes for BigInt64)
     this.gpuResolveBuffer = this.gpuDevice.createBuffer({
-      size: 16,
+      size: this.gpuTimestampBufferSize,
       usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.COPY_SRC
     });
+  }
 
-    // Double-buffered read buffers for async readback
-    for (let i = 0; i < 2; i++) {
-      this.gpuReadBuffers.push(this.gpuDevice.createBuffer({
-        size: 16,
-        usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
-      }));
+  private acquireReadBuffer(): GPUBuffer | null {
+    if (!this.gpuDevice) return null;
+    const recycled = this.readBufferPool.pop();
+    if (recycled) return recycled;
+
+    const totalLive = this.inFlightFrames.length + this.readBufferPool.length + 1;
+    if (totalLive > this.poolWarnThreshold && !this.warnedPoolGrowth) {
+      console.warn(
+        `stats-gl: WebGPU timestamp readback pool grew to ${totalLive} buffers — ` +
+        `is update() being called every frame after queue.submit?`
+      );
+      this.warnedPoolGrowth = true;
     }
+    return this.gpuDevice.createBuffer({
+      size: this.gpuTimestampBufferSize,
+      usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+    });
   }
 
   protected handleThreeRenderer(renderer: any): boolean {
@@ -255,24 +295,48 @@ export class StatsCore {
   }
 
   /**
-   * Get timestampWrites configuration for WebGPU render pass.
-   * Use this when creating your render pass descriptor.
-   * @returns timestampWrites object or undefined if not tracking GPU
+   * Allocate a fresh timestamp pair (beginning + end) and return the descriptor
+   * to embed in a render or compute pass. Each call consumes one pair from the
+   * per-frame budget; counters reset on the next `begin()`.
+   *
+   * @param type - 'render' (default) or 'compute' — controls which panel the
+   *               resolved duration is added to.
+   * @returns timestampWrites object, or `undefined` if the native WebGPU path
+   *          is not active or the per-frame pair budget is exhausted.
    */
-  public getTimestampWrites(): GPURenderPassTimestampWrites | undefined {
+  public getTimestampWrites(
+    type: TimestampPassType = 'render'
+  ): GPURenderPassTimestampWrites | undefined {
     if (!this.webgpuNative || !this.gpuQuerySet) return undefined;
+    if (this.frameCursor >= this.maxTimestampPairs) {
+      if (!this.warnedSlotOverflow) {
+        console.warn(
+          `stats-gl: WebGPU timestamp pair budget exhausted ` +
+          `(maxTimestampPairs=${this.maxTimestampPairs}). ` +
+          `Increase maxTimestampPairs in StatsOptions to instrument more passes.`
+        );
+        this.warnedSlotOverflow = true;
+      }
+      return undefined;
+    }
+    const i = this.frameCursor++;
+    this.slotTypes[i] = type;
     return {
       querySet: this.gpuQuerySet,
-      beginningOfPassWriteIndex: 0,
-      endOfPassWriteIndex: 1
+      beginningOfPassWriteIndex: i * 2,
+      endOfPassWriteIndex: i * 2 + 1
     };
   }
 
   public begin(encoder?: GPUCommandEncoder): void {
     this.beginProfiling();
 
-    // For native WebGPU, timing is handled via timestampWrites in render pass
+    // For native WebGPU, timing is handled via timestampWrites in the
+    // render/compute pass descriptors returned by getTimestampWrites().
+    // Reset the per-frame slot allocator here so the next pass starts at index 0.
     if (this.webgpuNative) {
+      this.frameCursor = 0;
+      this.slotTypes.length = 0;
       return;
     }
 
@@ -291,18 +355,27 @@ export class StatsCore {
   public end(encoder?: GPUCommandEncoder): void {
     this.renderCount++;
 
-    // Handle native WebGPU timing - resolve query and copy to read buffer
-    if (this.webgpuNative && encoder && this.gpuQuerySet && this.gpuResolveBuffer && this.gpuReadBuffers.length > 0) {
-      // Track frame count for first-frame skip
-      this.gpuFrameCount++;
+    // Native WebGPU: resolve the slots used this frame and queue a buffer read.
+    if (this.webgpuNative && encoder && this.gpuQuerySet && this.gpuResolveBuffer) {
+      const usedPairs = this.frameCursor;
+      if (usedPairs > 0) {
+        const usedQueries = usedPairs * 2;
+        const usedBytes = usedQueries * 8;
+        // resolveQuerySet writes into gpuResolveBuffer, which is never mapped — safe to call always.
+        encoder.resolveQuerySet(this.gpuQuerySet, 0, usedQueries, this.gpuResolveBuffer, 0);
 
-      // Write to current buffer (will read from other buffer in resolve)
-      const writeBuffer = this.gpuReadBuffers[this.gpuWriteBufferIndex];
-
-      // Only add resolve commands if the target buffer is unmapped
-      if ((writeBuffer as any).mapState === 'unmapped') {
-        encoder.resolveQuerySet(this.gpuQuerySet, 0, 2, this.gpuResolveBuffer, 0);
-        encoder.copyBufferToBuffer(this.gpuResolveBuffer, 0, writeBuffer, 0, 16);
+        const readBuffer = this.acquireReadBuffer();
+        if (readBuffer) {
+          encoder.copyBufferToBuffer(this.gpuResolveBuffer, 0, readBuffer, 0, usedBytes);
+          this.inFlightFrames.push({
+            buffer: readBuffer,
+            pairCount: usedPairs,
+            slotTypes: this.slotTypes.slice(0, usedPairs),
+            mapPromise: null,
+            ready: false,
+            error: null
+          });
+        }
       }
 
       this.endProfiling();
@@ -319,63 +392,66 @@ export class StatsCore {
   }
 
   /**
-   * Resolve WebGPU timestamp queries. Call this after queue.submit().
-   * Returns a promise that resolves to the GPU duration in milliseconds.
+   * Drive the WebGPU timestamp readback pipeline. Call once per frame, AFTER
+   * queue.submit(). Kicks off mapAsync for any newly-submitted in-flight frames
+   * and drains any frames whose mapping has resolved (oldest first).
+   *
+   * Returns the most recently resolved render-pass duration in milliseconds.
    */
   public async resolveTimestampsAsync(): Promise<number> {
-    if (!this.webgpuNative || this.gpuReadBuffers.length === 0) {
-      return this.totalGpuDuration;
+    if (!this.webgpuNative) return this.totalGpuDuration;
+
+    // Kick off mapAsync for any frames that haven't started mapping yet.
+    // The user is expected to have called queue.submit() before update(),
+    // so the copy commands are now in flight on the GPU.
+    for (const entry of this.inFlightFrames) {
+      if (entry.mapPromise === null) {
+        entry.mapPromise = entry.buffer.mapAsync(GPUMapMode.READ).then(
+          () => { entry.ready = true; },
+          (e) => { entry.error = e; entry.ready = true; }
+        );
+      }
     }
 
-    // If there's already a pending resolve, wait for it
-    if (this.pendingResolve) {
-      return this.pendingResolve;
+    // Drain completed frames in submission order. Each completed frame
+    // overwrites totalGpuDuration / totalGpuDurationCompute, so the latest
+    // resolved frame's data is what the panels see.
+    while (this.inFlightFrames.length > 0 && this.inFlightFrames[0].ready) {
+      const entry = this.inFlightFrames.shift()!;
+      if (entry.error) {
+        if (!this.warnedMapError) {
+          console.warn('stats-gl: WebGPU timestamp mapAsync failed', entry.error);
+          this.warnedMapError = true;
+        }
+        this.totalGpuDuration = 0;
+        this.totalGpuDurationCompute = 0;
+        // Failed mapAsync leaves the buffer unmapped; safe to recycle.
+        this.readBufferPool.push(entry.buffer);
+        continue;
+      }
+
+      const data = new BigUint64Array(entry.buffer.getMappedRange());
+      let renderNs = 0;
+      let computeNs = 0;
+      for (let i = 0; i < entry.pairCount; i++) {
+        const start = data[i * 2];
+        const end = data[i * 2 + 1];
+        // Guard against rare disjoint timestamps (end < start) and stay in Number land.
+        const delta = end >= start ? Number(end - start) : 0;
+        if (entry.slotTypes[i] === 'compute') {
+          computeNs += delta;
+        } else {
+          renderNs += delta;
+        }
+      }
+      entry.buffer.unmap();
+      this.readBufferPool.push(entry.buffer);
+
+      this.totalGpuDuration = renderNs / 1_000_000;
+      this.totalGpuDurationCompute = computeNs / 1_000_000;
     }
 
-    // Read from the OTHER buffer (written in previous frame)
-    // Current frame writes to gpuWriteBufferIndex, so read from the other one
-    const readBufferIndex = (this.gpuWriteBufferIndex + 1) % 2;
-    const readBuffer = this.gpuReadBuffers[readBufferIndex];
-
-    // Toggle write buffer for next frame
-    this.gpuWriteBufferIndex = (this.gpuWriteBufferIndex + 1) % 2;
-
-    // Skip first frame (no previous data to read)
-    if (this.gpuFrameCount < 2) {
-      return this.totalGpuDuration;
-    }
-
-    // Only attempt to map if buffer is unmapped
-    if ((readBuffer as any).mapState !== 'unmapped') {
-      return this.totalGpuDuration;
-    }
-
-    this.pendingResolve = this._resolveTimestamps(readBuffer);
-
-    try {
-      const result = await this.pendingResolve;
-      return result;
-    } finally {
-      this.pendingResolve = null;
-    }
-  }
-
-  private async _resolveTimestamps(readBuffer: GPUBuffer): Promise<number> {
-    try {
-      await readBuffer.mapAsync(GPUMapMode.READ);
-      const data = new BigInt64Array(readBuffer.getMappedRange());
-      const startTime = data[0];
-      const endTime = data[1];
-      readBuffer.unmap();
-
-      // Convert nanoseconds to milliseconds
-      const durationNs = Number(endTime - startTime);
-      this.totalGpuDuration = durationNs / 1_000_000;
-      return this.totalGpuDuration;
-    } catch (_) {
-      // Buffer may have been destroyed or mapping failed
-      return this.totalGpuDuration;
-    }
+    return this.totalGpuDuration;
   }
 
   protected processGpuQueries(): void {
@@ -434,7 +510,7 @@ export class StatsCore {
   protected updateAverages(): void {
     this.addToAverage(this.totalCpuDuration, this.averageCpu);
     this.addToAverage(this.totalGpuDuration, this.averageGpu);
-    if (this.info && this.totalGpuDurationCompute !== undefined) {
+    if ((this.info || this.webgpuNative) && this.totalGpuDurationCompute !== undefined) {
       this.addToAverage(this.totalGpuDurationCompute, this.averageGpuCompute);
     }
   }
@@ -527,15 +603,27 @@ export class StatsCore {
       this.gpuResolveBuffer.destroy();
       this.gpuResolveBuffer = null;
     }
-    for (const buffer of this.gpuReadBuffers) {
-      if ((buffer as any).mapState === 'mapped') {
-        buffer.unmap();
+    for (const entry of this.inFlightFrames) {
+      try {
+        if ((entry.buffer as any).mapState === 'mapped') {
+          entry.buffer.unmap();
+        }
+      } catch (_) {
+        // Buffer may already be in a terminal state.
       }
+      entry.buffer.destroy();
+    }
+    this.inFlightFrames.length = 0;
+    for (const buffer of this.readBufferPool) {
       buffer.destroy();
     }
-    this.gpuReadBuffers.length = 0;
-    this.gpuFrameCount = 0;
-    this.pendingResolve = null;
+    this.readBufferPool.length = 0;
+    this.frameCursor = 0;
+    this.slotTypes.length = 0;
+    this.gpuTimestampBufferSize = 0;
+    this.warnedMapError = false;
+    this.warnedSlotOverflow = false;
+    this.warnedPoolGrowth = false;
     this.webgpuNative = false;
 
     // Clear references

--- a/llms.txt
+++ b/llms.txt
@@ -102,6 +102,46 @@ function animate() {
 animate();
 ```
 
+### Multi-pass / compute-pass timing
+
+Each `getTimestampWrites(type)` call allocates one timestamp pair from the per-frame
+budget. `'render'` pairs sum into the GPU panel, `'compute'` pairs into the CPT panel.
+Counters reset on `stats.begin()`.
+
+```js
+const stats = new Stats({ trackGPU: true, trackCPT: true });
+stats.init(device);
+
+function frame() {
+  stats.begin();
+  const encoder = device.createCommandEncoder();
+
+  const cp = encoder.beginComputePass({
+    timestampWrites: stats.getTimestampWrites('compute')
+  });
+  // dispatchWorkgroups...
+  cp.end();
+
+  const rp1 = encoder.beginRenderPass({
+    colorAttachments: [...],
+    timestampWrites: stats.getTimestampWrites('render')
+  });
+  // shadow pass...
+  rp1.end();
+
+  const rp2 = encoder.beginRenderPass({
+    colorAttachments: [...],
+    timestampWrites: stats.getTimestampWrites('render')
+  });
+  // main pass...
+  rp2.end();
+
+  stats.end(encoder);
+  device.queue.submit([encoder.finish()]);
+  stats.update();
+}
+```
+
 ## 5. Web Worker + OffscreenCanvas
 
 ### Main Thread
@@ -246,12 +286,13 @@ for (const { name, bitmap } of captures) {
 | trackFPS | true | FPS/CPU panels |
 | trackGPU | false | GPU timing |
 | trackHz | false | Refresh rate |
-| trackCPT | false | Compute timing (WebGPU) |
+| trackCPT | false | Compute-pass timing (WebGPU). Adds CPT panel. |
 | logsPerSecond | 4 | Text update rate |
 | graphsPerSecond | 30 | Graph update rate |
 | samplesLog | 40 | Text averaging samples |
 | samplesGraph | 10 | Graph averaging samples |
 | precision | 2 | Decimal places |
+| maxTimestampPairs | 2048 | Max begin/end pairs per frame (native WebGPU) |
 | minimal | false | Click-to-cycle mode |
 | horizontal | true | Panel layout |
 | mode | 0 | Initial panel |
@@ -261,12 +302,13 @@ for (const { name, bitmap } of captures) {
 ### Stats (default export)
 
 ```js
-stats.init(renderer)              // Init with Three.js renderer, canvas, or GPUDevice
-stats.begin()                     // Start timing
-stats.end(encoder?)               // End timing (pass encoder for native WebGPU)
-stats.update()                    // Update display
-stats.getTimestampWrites()        // Get timestampWrites for native WebGPU render pass
-stats.setData({ fps, cpu, gpu })  // External data (workers)
+stats.init(renderer)                  // Init with Three.js renderer, canvas, or GPUDevice
+stats.begin()                         // Start timing
+stats.end(encoder?)                   // End timing (pass encoder for native WebGPU)
+stats.update()                        // Update display
+stats.getTimestampWrites('render')    // Allocate render-pass timestamp pair
+stats.getTimestampWrites('compute')   // Allocate compute-pass timestamp pair
+stats.setData({ fps, cpu, gpu })      // External data (workers)
 stats.addPanel(panel)             // Custom panel
 stats.addTexturePanel(name)       // Texture preview
 stats.setTexture(name, target)    // Set texture source
@@ -277,12 +319,12 @@ stats.dispose()                   // Cleanup
 ### StatsProfiler (headless for workers)
 
 ```js
-profiler.init(gl | device)        // Init with GL context or GPUDevice
-profiler.begin()                  // Start timing
-profiler.end(encoder?)            // End timing (pass encoder for native WebGPU)
-profiler.update()                 // Process data
-profiler.getTimestampWrites()     // Get timestampWrites for native WebGPU
-profiler.getData()                // { fps, cpu, gpu, gpuCompute }
+profiler.init(gl | device)            // Init with GL context or GPUDevice
+profiler.begin()                      // Start timing
+profiler.end(encoder?)                // End timing (pass encoder for native WebGPU)
+profiler.update()                     // Process data
+profiler.getTimestampWrites(type?)    // 'render' (default) or 'compute' pair
+profiler.getData()                    // { fps, cpu, gpu, gpuCompute }
 profiler.captureTexture(src, id)  // Capture to ImageBitmap
 profiler.dispose()                // Cleanup
 ```

--- a/webgpu.html
+++ b/webgpu.html
@@ -126,11 +126,11 @@
         <a href="/worker_tsl.html" class="nav-tab">Worker TSL</a>
       </div>
       <pre>
-<span class="comment">// Native WebGPU example</span>
+<span class="comment">// Native WebGPU - multi-pass timing</span>
 
 <span class="keyword">import</span> Stats <span class="keyword">from</span> <span class="string">'stats-gl'</span>
 
-<span class="keyword">const</span> stats = <span class="keyword">new</span> Stats({ trackGPU: true });
+<span class="keyword">const</span> stats = <span class="keyword">new</span> Stats({ trackGPU: true, trackCPT: true });
 <span class="keyword">await</span> stats.init(device);
 document.body.appendChild(stats.dom);
 
@@ -138,12 +138,20 @@ document.body.appendChild(stats.dom);
     <span class="keyword">const</span> encoder = device.createCommandEncoder();
     stats.begin();
 
-    <span class="keyword">const</span> pass = encoder.beginRenderPass({
+    <span class="comment">// Compute pass → CPT panel</span>
+    <span class="keyword">const</span> cp = encoder.beginComputePass({
+        timestampWrites: stats.getTimestampWrites(<span class="string">'compute'</span>)
+    });
+    <span class="comment">// dispatchWorkgroups...</span>
+    cp.end();
+
+    <span class="comment">// Render pass → GPU panel</span>
+    <span class="keyword">const</span> rp = encoder.beginRenderPass({
         colorAttachments: [...],
-        timestampWrites: stats.getTimestampWrites()
+        timestampWrites: stats.getTimestampWrites(<span class="string">'render'</span>)
     });
     <span class="comment">// draw calls</span>
-    pass.end();
+    rp.end();
 
     stats.end(encoder);
     device.queue.submit([encoder.finish()]);
@@ -209,7 +217,7 @@ document.body.appendChild(stats.dom);
         });
 
         // Initialize stats with native WebGPU device
-        const stats = new Stats({ trackGPU: true, trackHz: true });
+        const stats = new Stats({ trackGPU: true, trackCPT: true, trackHz: true });
         await stats.init(device);
         document.body.appendChild(stats.dom);
 
@@ -314,6 +322,49 @@ document.body.appendChild(stats.dom);
           }]
         });
 
+        // ---- Compute pass setup (exercises stats.getTimestampWrites('compute')) ----
+        const computeShaderModule = device.createShaderModule({
+          code: `
+            @group(0) @binding(0) var<storage, read_write> data: array<u32, 64>;
+
+            @compute @workgroup_size(64)
+            fn computeMain(@builtin(global_invocation_id) gid: vec3u) {
+              data[gid.x] = data[gid.x] + 1u;
+            }
+          `
+        });
+
+        const computeBuffer = device.createBuffer({
+          size: 64 * 4,
+          usage: GPUBufferUsage.STORAGE
+        });
+
+        const computeBindGroupLayout = device.createBindGroupLayout({
+          entries: [{
+            binding: 0,
+            visibility: GPUShaderStage.COMPUTE,
+            buffer: { type: 'storage' }
+          }]
+        });
+
+        const computePipeline = device.createComputePipeline({
+          layout: device.createPipelineLayout({
+            bindGroupLayouts: [computeBindGroupLayout]
+          }),
+          compute: {
+            module: computeShaderModule,
+            entryPoint: 'computeMain'
+          }
+        });
+
+        const computeBindGroup = device.createBindGroup({
+          layout: computeBindGroupLayout,
+          entries: [{
+            binding: 0,
+            resource: { buffer: computeBuffer }
+          }]
+        });
+
         // Animation variables
         let rotation = 0;
         let lastTime = 0;
@@ -343,26 +394,50 @@ document.body.appendChild(stats.dom);
           // Create command encoder
           const encoder = device.createCommandEncoder();
 
-          // Begin CPU timing
+          // Begin CPU timing (also resets the per-frame timestamp slot allocator)
           stats.begin();
 
-          // Begin render pass with timestampWrites for GPU timing
-          const pass = encoder.beginRenderPass({
+          // Compute pass - timed into the CPT panel
+          const computePass = encoder.beginComputePass({
+            timestampWrites: stats.getTimestampWrites('compute')
+          });
+          computePass.setPipeline(computePipeline);
+          computePass.setBindGroup(0, computeBindGroup);
+          computePass.dispatchWorkgroups(1);
+          computePass.end();
+
+          const textureView = context.getCurrentTexture().createView();
+
+          // First render pass - clears canvas + draws the triangle
+          const pass1 = encoder.beginRenderPass({
             colorAttachments: [{
-              view: context.getCurrentTexture().createView(),
+              view: textureView,
               loadOp: 'clear',
               storeOp: 'store',
               clearValue: { r: 0.1, g: 0.1, b: 0.1, a: 1.0 }
             }],
-            timestampWrites: stats.getTimestampWrites()
+            timestampWrites: stats.getTimestampWrites('render')
           });
+          pass1.setPipeline(pipeline);
+          pass1.setBindGroup(0, bindGroup);
+          pass1.draw(3);
+          pass1.end();
 
-          pass.setPipeline(pipeline);
-          pass.setBindGroup(0, bindGroup);
-          pass.draw(3);
-          pass.end();
+          // Second render pass - overlays another triangle (loads existing contents)
+          const pass2 = encoder.beginRenderPass({
+            colorAttachments: [{
+              view: textureView,
+              loadOp: 'load',
+              storeOp: 'store'
+            }],
+            timestampWrites: stats.getTimestampWrites('render')
+          });
+          pass2.setPipeline(pipeline);
+          pass2.setBindGroup(0, bindGroup);
+          pass2.draw(3);
+          pass2.end();
 
-          // End timing and resolve GPU timestamps
+          // End timing and resolve all timestamp pairs used this frame
           stats.end(encoder);
 
           // Submit commands


### PR DESCRIPTION
## Summary

Rewrites the native WebGPU timestamp-query path in `lib/core.ts` to be frame-perfect, multi-pass capable, and spec-correct. Backward compatible with the existing single-pass usage documented in `README.md` and `webgpu.html`.

Cross-checked against [webgpufundamentals.org/webgpu/lessons/webgpu-timing.html](https://webgpufundamentals.org/webgpu/lessons/webgpu-timing.html) and Three.js's own `WebGPUTimestampQueryPool`.

## What was wrong before

1. **Used `BigInt64Array` for u64 nanosecond timestamps** — spec-incorrect, mismatches Three.js.
2. **2-buffer ping-pong dropped frames under load.** If `mapAsync` ever took longer than a frame, the write-buffer index didn't toggle and `end()` silently skipped `resolveQuerySet`/`copyBufferToBuffer` until the in-flight map resolved.
3. **Single render pass per frame only.** `getTimestampWrites()` always returned indices `0/1` against a `count: 2` QuerySet. Apps with multiple render passes silently overwrote the same slots.
4. **No native compute-pass timing.** `trackCPT` only worked through Three.js's `renderer.info.compute.timestamp`; raw-WebGPU users got nothing.
5. Misc: `resolveQuerySet` was unnecessarily gated on `mapState`; magic `16` for buffer size; silent forever-retry on mapAsync errors.

## What changed

### `lib/core.ts`
- `BigInt64Array` → `BigUint64Array`.
- 2-buffer ping-pong → **dynamic `readBufferPool` + `inFlightFrames` queue**. Pool grows on demand and plateaus at the steady-state in-flight depth (typically 2–3); warns once if pool exceeds 8 buffers.
- `count: 2` QuerySet → **`count: maxTimestampPairs * 2`** (default 2048 pairs, matches Three.js). Configurable via new `StatsCoreOptions.maxTimestampPairs`.
- New per-frame slot allocator: `getTimestampWrites('render' | 'compute')` hands out independent pairs each call. `begin()` resets the cursor; `end(encoder)` resolves only the slots actually used.
- `resolveTimestampsAsync()` kicks off `mapAsync` for new in-flight frames and drains completed ones in submission order, sorting render vs compute durations into `totalGpuDuration` / `totalGpuDurationCompute`.
- `mapAsync` failure logs once and zeros the duration instead of silently retaining stale values.
- `updateAverages` now feeds compute durations into `averageGpuCompute` on the native path, not just Three.js.

### `README.md` + `llms.txt`
- Document the new `'render' | 'compute'` argument and the multi-pass usage pattern.
- Document the `maxTimestampPairs` option.
- Update `trackCPT` description: works on native WebGPU, not just Three.js.

### `webgpu.html`
- Demo now exercises one compute pass + two render passes per frame, each with its own timestamp pair (`trackCPT: true` so the CPT panel updates).
- Visible code overlay shows the new pattern.

## Backward compatibility

For users following the documented pattern, this is a drop-in upgrade:

```js
// Before and after — identical behavior
timestampWrites: stats.getTimestampWrites()
```

Only behavioral diff visible in normal usage: calling `getTimestampWrites()` more than once per frame now returns independent pairs (was silently overwriting). That's a fix.

The Three.js WebGPURenderer path (`renderer.info.{render,compute}.timestamp`) and the WebGL2 `EXT_disjoint_timer_query_webgl2` path are untouched.

## Test plan

- [x] `npm run build` — clean (TypeScript + Vite + Rollup d.ts).
- [x] `npm run dev` — vite serves all demos cleanly (`webgpu.html`, `index.html`, `webgl.html`, `worker.html`).
- [x] `dist/stats-gl.d.ts` exports `getTimestampWrites(type?: TimestampPassType)` and `maxTimestampPairs?: number`.
- [ ] Open `webgpu.html` in Chrome 113+: confirm GPU + CPT panels both update with non-zero ms values.
- [ ] Open `index.html` (Three.js path): confirm GPU + CPT panels behave identically to before.
- [ ] Stress test: heavy `for` loop of `pass.draw(...)` — confirm no `0` ms gaps in the GPU panel graph (was the failure mode before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)