### PR TITLE
fix: guard CPU profiling duration

### DIFF
--- a/lib/core.ts
+++ b/lib/core.ts
@@ -100,6 +100,7 @@ export class StatsCore {
   protected renderCount = 0;
 
   protected cpuStartTime = 0;
+  protected isRunningCPUProfiling = false;
   protected totalCpuDuration = 0;
   protected totalGpuDuration = 0;
   protected totalGpuDurationCompute = 0;
@@ -482,10 +483,14 @@ export class StatsCore {
 
   protected beginProfiling(): void {
     this.cpuStartTime = performance.now();
+    this.isRunningCPUProfiling = true;
   }
 
   protected endProfiling(): void {
-    this.totalCpuDuration += performance.now() - this.cpuStartTime;
+    if (this.isRunningCPUProfiling) {
+      this.totalCpuDuration += performance.now() - this.cpuStartTime;
+      this.isRunningCPUProfiling = false;
+    }
   }
 
   protected calculateFps(): number {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stats-gl",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "type": "module",
   "author": "Renaud ROHLINGER (https://github.com/RenaudRohlinger)",
   "homepage": "https://github.com/RenaudRohlinger/stats-gl",


### PR DESCRIPTION
Summary:
- guard CPU profiling so duplicate endProfiling calls do not double-count elapsed time
- bump package version to 4.2.1

Verification:
- npm run build
- git diff --check